### PR TITLE
Fix overflow panic in TextRenderer::draw_string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,11 +253,10 @@ where
                     g.draw(|off_x, off_y, v| {
                         let off_x = off_x as i32 + bb.min.x;
                         let off_y = off_y as i32 + bb.min.y;
+                        let text_a = (v.clamp(0.0, 1.0) * 255.0) as u32;
                         // There's still a possibility that the glyph clips the boundaries of the bitmap
                         if off_x >= 0 && off_x < width as i32 && off_y >= 0 && off_y < height as i32
                         {
-                            let text_a = (v * 255.0) as u32;
-
                             let bg_color = match self.anti_aliasing {
                                 AntiAliasing::BackgroundColor => self.background_color,
                                 AntiAliasing::SolidColor(c) => Some(c),


### PR DESCRIPTION
The callback function to PositionedGlyph::draw() can be passed a alpha (coverage) value greater than 1.0. Clamp to 1.0 to avoid a panic: `attempt to subtract with overflow` in FontTextStyle::draw_string().

Details:
FontTextStyle::draw_string() calls[1] rusttype::PositionedGlyph::draw() which eventually calls for_each_pixel_2d in ab_glyph_rasterizer. According to the docs[2] this value can be greater than 1.0.

This PR fixes #1.

[1]: https://github.com/peckpeck/embedded-ttf/blob/cede1c9117806398f23a948ac1d15bf66e26a163/src/lib.rs#L253
[2]: https://docs.rs/ab_glyph_rasterizer/0.1.10/ab_glyph_rasterizer/struct.Rasterizer.html#method.for_each_pixel